### PR TITLE
 Use Tempo Cloud API instead of Selenium

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# http://editorconfig.org/
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_style = space
+indent_size = 4

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,18 @@
 jira_timemachine
 ================
 
+This package copies worklogs from a source Jira to an issue in a destination Jira. It's idempotent: rerunning it
+updates already copied worklogs instead of duplicating them.
+
 .. warning::
 
     This might log you out from cloud jira browser session!
-
 
 To re-write your worklog for the last three days from one JIRA to another, use timemachine command:
 
 .. code-block::
 
     timemachine --config example_config/config.json --days 3
+
+Check the example config for the needed fields; Tempo access requires generating a personal access token, see
+<https://tempo-io.atlassian.net/wiki/spaces/TEMPO/pages/199065601/How+to+use+Tempo+Cloud+REST+APIs#HowtouseTempoCloudRESTAPIs-Createapersonalauthorizationtoken>.

--- a/example_config/config.sample.json
+++ b/example_config/config.sample.json
@@ -4,13 +4,15 @@
     "login": "login",
     "email": "login@login.com",
     "password": "pass",
-    "project_key": "JIRA"
+    "project_key": "JIRA",
+    "tempo_token": ""
   },
   "destination_jira": {
     "url": "https://destination.atlassian.net",
     "login": "login",
     "email": "login@login.com",
     "password": "pass",
-    "issue": "JIRA-123"
+    "issue": "JIRA-123",
+    "tempo_token": ""
   }
 }

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,2 @@
+[FORMAT]
+max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,6 @@ requirements = [
     'Click',
     'jira',
     'arrow',
-    'Selenium',
-    'splinter',
     'typing',
 ]
 
@@ -41,7 +39,7 @@ extras_require = {
 setup(
     name='jira_timemachine',
     version=package_version,
-    description='It\'s a python package template only',
+    description='Synchronize worklogs between Jira instances',
     long_description=(
         read('README.rst') + '\n\n' + read('CHANGES.rst')
     ),


### PR DESCRIPTION
Do not sync days containing worklogs from previous jira-timemachine versions: now Jira worklog IDs are used to identify worklogs instead of Tempo worklog IDs. This should allow future transitions of source Jiras to/from Tempo without incompatible worklog naming changes.

Fixes #1