### PR TITLE
Fix failing docker build

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,6 @@
 pytest==3.9.3
 pytest-cov==2.6.0
 pylint==1.9.3; python_version < "3"
-pylint==2.1.1; python_version >= "3"
+pylint=2.3.1; python_version >= "3"
 mock==2.0.0
 mypy==0.641


### PR DESCRIPTION
Building image was failing with import issue.

```
Step 10/13 : RUN pylint src/jira_timemachine                                                                                                            
 ---> Running in 7bae5233dd44                                                                                                                              
Traceback (most recent call last):                                                                                                                         
  File "/usr/local/bin/pylint", line 11, in <module>                                                                                                                
    sys.exit(run_pylint())                                                                                                                                             
  File "/usr/local/lib/python3.7/site-packages/pylint/__init__.py", line 19, in run_pylint                                                                          
    Run(sys.argv[1:])                                                                                                                                      
  File "/usr/local/lib/python3.7/site-packages/pylint/lint.py", line 1394, in __init__                                                                                                        
    linter.check(args)                                                                                                                                              
  File "/usr/local/lib/python3.7/site-packages/pylint/lint.py", line 801, in check                                                                                                            
    self._do_check(files_or_modules)                                                                                                                                                          
  File "/usr/local/lib/python3.7/site-packages/pylint/lint.py", line 938, in _do_check                                                                                                        
    self.check_astroid_module(ast_node, walker, rawcheckers, tokencheckers)                                                                                                                   
  File "/usr/local/lib/python3.7/site-packages/pylint/lint.py", line 1018, in check_astroid_module                                                                              
    walker.walk(ast_node)                                                                                                                        
  File "/usr/local/lib/python3.7/site-packages/pylint/utils.py", line 1162, in walk                                                                                                           
    self.walk(child)                                                                                                                                           
  File "/usr/local/lib/python3.7/site-packages/pylint/utils.py", line 1159, in walk                                                                                                           
    cb(astroid)                                                                                                                                                                               
  File "/usr/local/lib/python3.7/site-packages/pylint/checkers/variables.py", line 1360, in visit_import                                                                                      
    module = next(node.infer_name_module(parts[0]))                                                                                                                                           
AttributeError: 'Import' object has no attribute 'infer_name_module'                                                                                                
The command '/bin/sh -c pylint src/jira_timemachine' returned a non-zero code: 1           
```

Bumping pylint fix it.