### PR TITLE
Use Tempo Cloud API version 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,13 @@ RUN pip install .
 
 FROM app as tests
 
-# Run tests here.
+# Run linters and tests.
 RUN pip install .[tests]
 RUN pylint src/jira_timemachine
 RUN mypy src/jira_timemachine tests
 RUN pytest
+# List outdated dependencies.
+RUN pip list -o
 
 FROM app
 

--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,8 @@ Build the image::
 
 Run ``timemachine``::
 
-  docker run -v $PWD/example_config:/config timemachine timemachine --config /config/config.json
+  docker run --rm -v $PWD/example_config:/config timemachine timemachine --config /config/config.json
 
 Run ``timecheck``::
 
-  docker run -v $PWD/example_config:/config timemachine timecheck --config /config/config.json
+  docker run --rm -v $PWD/example_config:/config timemachine timecheck --config /config/config.json

--- a/example_config/config.sample.json
+++ b/example_config/config.sample.json
@@ -1,7 +1,6 @@
 {
   "source_jira": {
     "url": "https://source.atlassian.net",
-    "login": "login",
     "email": "login@login.com",
     "jira_token": "",
     "project_key": "JIRA",
@@ -9,7 +8,6 @@
   },
   "destination_jira": {
     "url": "https://destination.atlassian.net",
-    "login": "login",
     "email": "login@login.com",
     "jira_token": "",
     "issue": "JIRA-123",

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,6 @@
-pytest==3.9.3
-pytest-cov==2.6.0
+pytest==4.4.0
+pytest-cov==2.6.1
 pylint==1.9.3; python_version < "3"
-pylint=2.3.1; python_version >= "3"
+pylint==2.3.1; python_version >= "3"
 mock==2.0.0
-mypy==0.641
+mypy==0.700

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-arrow==0.12.1
-attrs==18.2.0
+arrow==0.13.1
+attrs==19.1.0
 Click==7.0
 jira==2.0.0
-six==1.11.0
+six==1.12.0
 typing==3.6.6

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -21,7 +21,7 @@ def test_worklog_to_tempo():
         issue=u'X-11',
         ).to_tempo() == {
             'attributes': [],
-            'authorUsername': u'q.atester',
+            'authorAccountId': u'q.atester',
             'description': u'Invent test data',
             'issueKey': u'X-11',
             'startDate': u'2018-11-16',
@@ -30,11 +30,11 @@ def test_worklog_to_tempo():
         }
 
 
-@pytest.mark.parametrize('all_users, user_name', (
-    (False, 'the.user'),
-    (True, None),
+@pytest.mark.parametrize('all_users, single_user', (
+    (False, True),
+    (True, False),
 ))
-def test_get_worklogs(all_users, user_name):
+def test_get_worklogs(all_users, single_user):
     """Test that get_worklogs performs proper calls and filters worklogs by date."""
     old_sample_worklogs = [
         Worklog(id=1, tempo_id=2, started=arrow.get('2018-11-10'), time_spent_seconds=1, description=u'', author=u'', issue=u''),
@@ -51,7 +51,7 @@ def test_get_worklogs(all_users, user_name):
 
     assert mock_get_client.mock_calls == [
         call(config),
-        call().get_worklogs(from_date=date(2018, 11, 16), username=user_name),
+        call().get_worklogs(from_date=date(2018, 11, 16), single_user=single_user),
     ]
 
 


### PR DESCRIPTION
User names are replaced by account IDs obtained via the JIRA API.

Now every JIRA needs JIRA credentials, not only the Tempo token. The login config field is not used.

Fixes #13